### PR TITLE
Add warning in input_output due to breaking matplotlib code

### DIFF
--- a/book/input_output.md
+++ b/book/input_output.md
@@ -13,6 +13,9 @@ kernelspec:
 
 # Input-Output Models
 
+```{include} _admonition/wasm-compat.md
+```
+
 ## Overview
 
 This lecture requires the following imports and installs before we proceed.


### PR DESCRIPTION
Add warning in `input_output` due to breaking matplotlib code

Fixes #22 