### PR TITLE
Hide pip install output to suppress piplite 404 warnings

### DIFF
--- a/lectures/french_rev.md
+++ b/lectures/french_rev.md
@@ -62,6 +62,8 @@ This lecture uses data from three spreadsheets assembled by {cite}`sargent_velde
   * [datasets/assignat.xlsx](https://github.com/QuantEcon/lecture-python-intro/blob/main/lectures/datasets/assignat.xlsx)
 
 ```{code-cell} ipython3
+:tags: [hide-output]
+
 %pip install openpyxl requests
 ```
 

--- a/lectures/long_run_growth.md
+++ b/lectures/long_run_growth.md
@@ -65,6 +65,8 @@ be interesting to describe both total GDP and GDP per capita as it evolves withi
 First we will need to install the following package
 
 ```{code-cell} ipython3
+:tags: [hide-output]
+
 %pip install openpyxl
 ```
 


### PR DESCRIPTION
Add `:tags: [hide-output]` to `%pip install` code cells in `long_run_growth.md` and `french_rev.md` to suppress noisy piplite 404 warnings.

The other active lectures with `%pip install` cells (`inflation_history`, `eigen_II`, `markov_chains_I`, `markov_chains_II`, `networks`) already had this tag.

The 404 warnings are cosmetic — installs succeed via micropip fallback — but are confusing for users. The root cause is tracked in #42 (upstream `mystmd` limitation).
