### PR TITLE
ci: upgrade to mystmd 1.9.1 + Node 20 for quantecon-theme v2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,14 @@ jobs:
 
     - uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: 20.x
 
     - name: Install MyST Markdown CLI
       run: |
-        # TODO: Pin myst version to fix the breaking change.
-        npm install -g mystmd@1.6.2 thebe-core thebe thebe-lite
+        # mystmd 1.9.x emits the notebook output-node AST expected by the
+        # quantecon-theme v2.0.0 bundle (@myst-theme 1.x); Node >=20 is required
+        # to run that theme during `myst build`. See QuantEcon/quantecon-theme-src.
+        npm install -g mystmd@1.9.1 thebe-core thebe thebe-lite
 
     - name: Build HTML for GitHub Pages
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ This repository contains a WASM-compatible subset of the QuantEcon lecture serie
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) 18.x or higher
+- [Node.js](https://nodejs.org/) 20.x or higher
 
 ### Build and serve locally
 
 ```bash
 # Install dependencies
-npm install -g mystmd thebe-core thebe thebe-lite
+npm install -g mystmd@1.9.1 thebe-core thebe thebe-lite
 
 # Build
 cd lectures


### PR DESCRIPTION
## Upgrade build toolchain for quantecon-theme v2.0.0

The QuantEcon MyST theme bundle (`QuantEcon/quantecon-theme`) is now **v2.0.0** — the `@myst-theme` 0.14 → 1.x upgrade. Since `lectures/myst.yml` tracks the theme's unpinned `main.zip`, the **next** build of this site uses 2.0.0, which carries a breaking change.

### What changed (`.github/workflows/ci.yml`)
- **Node 18 → 20** — `myst build --html` runs the theme's SSR during the build, and the v2.0.0 bundle declares `engines: node >=20`.
- **`mystmd@1.6.2` → `mystmd@1.9.1`** — the 1.x theme renders the **new notebook output-node AST**; content built with 1.6.2 emits the old shape, so notebook outputs (stream / `execute_result` / error) would render incorrectly. Also clears the existing `TODO: Pin myst version to fix the breaking change`.

### No current breakage
The live GitHub Pages site is static HTML frozen on the previous theme, so nothing is broken today — this makes the *next* build correct.

### Verification
The **Netlify preview** built by this PR renders the real site against the live v2.0.0 theme — that preview **is** the render check. (Already verified locally that the v2.0.0 bundle renders lecture-wasm correctly: centered content column, restored "On this page" outline, notebook outputs, and no hydration reload loop.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)