### PR TITLE
Pin quantecon-theme template to v2.0.0 commit for reproducible builds

### DIFF
--- a/lectures/myst.yml
+++ b/lectures/myst.yml
@@ -117,4 +117,7 @@ project:
       template: Fig. %s
   
 site:
-  template: https://github.com/QuantEcon/quantecon-theme/archive/refs/heads/main.zip
+  # Pinned to quantecon-theme v2.0.0 (commit 2ca0a12d) for reproducible builds.
+  # The bare main.zip tracks the branch HEAD, so theme changes land with no version
+  # bump here; bump this SHA deliberately when adopting a new theme release.
+  template: https://github.com/QuantEcon/quantecon-theme/archive/2ca0a12d062c051f6236cfdc1d320158fbc3d69c.zip


### PR DESCRIPTION
## What

Pins the site `template` in `lectures/myst.yml` from the branch-tracking `quantecon-theme/archive/refs/heads/main.zip` to the **v2.0.0 commit** `2ca0a12d`:

```
https://github.com/QuantEcon/quantecon-theme/archive/2ca0a12d062c051f6236cfdc1d320158fbc3d69c.zip
```

## Why

The bare `main.zip` tracks the theme repo's branch HEAD, so theme changes land here with **no version bump and no way to reproduce a build**. The recent v1.x → v2.0.0 jump arrived automatically this way, which is what surfaced both the "Cannot render output node" fix (handled by the mystmd 1.9.1 pin) and a transient in-page-execution hang during review. Pinning makes builds deterministic.

Bump the SHA deliberately when adopting a new theme release. There are no git tags on `quantecon-theme` to pin to, so a commit SHA is used.

## Notes

- The commit-pinned archive URL resolves (HTTP 200) and contains the same v2.0.0 theme `main` currently produces, so this is a no-op for the *current* rendered output — it only freezes the version.
- Context on the v2.0.0 transition: QuantEcon/quantecon-theme-src#74 (closed as transient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)