### PR TITLE
chore: pin site.template to the quantecon-theme v2.1.0 release zip

### DIFF
--- a/lectures/myst.yml
+++ b/lectures/myst.yml
@@ -117,4 +117,6 @@ project:
       template: Fig. %s
   
 site:
-  template: https://github.com/QuantEcon/quantecon-theme/archive/refs/heads/main.zip
+  # Pinned theme release (see https://github.com/QuantEcon/quantecon-theme.mystmd/releases);
+  # bump the vX.Y.Z in this URL to take a new theme version.
+  template: https://github.com/QuantEcon/quantecon-theme.mystmd/releases/download/v2.1.0/quantecon-theme.zip


### PR DESCRIPTION
## Summary

Repoints `site.template` from the **moving** `main`-branch archive of the legacy build repo (`QuantEcon/quantecon-theme`) to the **pinned v2.1.0 release asset** published by the theme's source repo:

```yaml
site:
  template: https://github.com/QuantEcon/quantecon-theme.mystmd/releases/download/v2.1.0/quantecon-theme.zip
```

This is the consumer-migration step of the theme's Phase 0 release modernisation — see QuantEcon/quantecon-theme.mystmd#80 and its PLAN.md. `lecture-wasm` is currently the only consumer. After this merges, the old build repo gets archived, so the old URL would eventually stop receiving updates anyway; pinning also means theme upgrades become deliberate, reviewable bumps of the `vX.Y.Z` in this URL (a comment in `myst.yml` documents that).

**What's in v2.1.0 vs the previously served bundle (v2.0.0):** flat-TOC sidebar entries are now clickable links, the Safari FOUC fix on navigation, and security dependency overrides — see the [release notes](https://github.com/QuantEcon/quantecon-theme.mystmd/releases/tag/v2.1.0).

## Verification

Ran `myst start` locally on this branch: the template is fetched from the release URL (`💾 Saved template`), all 42 lectures build, and the site serves through the v2.1.0 theme (title and lecture links verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)