### PR TITLE
Read the SCF sample from high_dim_data main

### DIFF
--- a/lectures/mle.md
+++ b/lectures/mle.md
@@ -92,7 +92,7 @@ The following code imports this data  and reads it into an array called `sample`
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-url = 'https://media.githubusercontent.com/media/QuantEcon/high_dim_data/update_scf_noweights/SCF_plus/SCF_plus_mini_no_weights.csv'
+url = 'https://github.com/QuantEcon/high_dim_data/raw/main/SCF_plus/SCF_plus_mini_no_weights.csv'
 df = pd.read_csv(url)
 df = df.dropna()
 df = df[df['year'] == 2016]


### PR DESCRIPTION
Repoints the SCF+ wealth sample in `mle.md` off the `update_scf_noweights` branch of `high_dim_data` and onto `main`. Part of risk 1 in QuantEcon/meta#337.

> **Unblocked and verified.** [QuantEcon/high_dim_data#6](https://github.com/QuantEcon/high_dim_data/pull/6) merged 2026-07-15, so the data is on `main` and this URL now resolves. Ready to review.

## What this fixes

This lecture has fetched its data from an **unmerged PR's branch** since 2023:

```
https://media.githubusercontent.com/media/QuantEcon/high_dim_data/update_scf_noweights/SCF_plus/SCF_plus_mini_no_weights.csv
```

A lecture build pinned to a non-default ref is a build that any branch cleanup breaks silently — and that pin is precisely why the branch could not be deleted. #6 put the file on `main`; this points the lecture at it.

## This is a 4-repo set, not a one-liner

The pin was tracked as living in `lecture-python-intro` alone. An org-wide code search shows **four** source repos carry it, each with its own copy of `mle.md`. All four get the identical change, on the same branch name (`datasets/repoint-scf-main`) with the same commit subject, so the set tracks as one:

| Repo | PR | |
| --- | --- | --- |
| `lecture-python-intro` | QuantEcon/lecture-python-intro#793 | the tracked one |
| `lecture-intro.zh-cn` | QuantEcon/lecture-intro.zh-cn#222 | live Chinese translation |
| `lecture-wasm` | QuantEcon/lecture-wasm#50 | WASM/pyodide variant |
| `test-lecture-python-intro` | QuantEcon/test-lecture-python-intro#48 | actions test fixture — genuinely builds `mle.md` (it is in its `_toc.yml`, with `ci.yml` and `linkcheck.yml`) |

`lecture-python-intro.notebooks` also references it, but it is a generated artifact and self-heals on the next rebuild. **The `update_scf_noweights` branch may only be deleted once all four of these merge** — that is the last step of meta#337 risk 1, and it is the only destructive one.

## Why the `/raw/` form and not `media.githubusercontent.com`

Both serve this LFS-tracked file today. Only `github.com/.../raw/main/...` also works if the file ever **stops** being LFS — which it will, when the consolidation folds `high_dim_data` into `data-lectures` (PLAN Phase 3), a repo that deliberately drops `high_dim_data`'s blanket `*.csv filter=lfs` rule. Repointing to `/raw/` now means this URL never has to change again.

## Verification

Checked end-to-end against `main` after #6 merged:

- **The bytes are identical.** The LFS object on `main` carries the same OID the branch served — `sha256:c3b2c78a…`, 75902999 bytes — so lecture output cannot change. This is the whole migration-integrity question, answered without downloading twice.
- **The URL resolves.** `github.com/.../raw/main/...` → **200**, real CSV (`year,n_wealth,t_income,l_income,nw_groups,ti_groups`), 302ing to the LFS media host.
- **The lecture's own cell runs unchanged.** Ran `mle.md`'s exact pipeline against the new URL: 1,672,214 rows fetched, 108,783 after the `year == 2016` and `n_wealth > 1` filters, and a deterministic 10,000-row sample (`random_state=1234`, mean 6.56 in $100,000 units).
- **The URL form is load-bearing.** `raw.githubusercontent.com/.../main/...` serves **LFS pointer text**, not data — verified against the sibling `SCF_plus_mini.csv`, which was already on `main`. Using that form would have failed as a parse error rather than an obvious hosting bug.

Part of QuantEcon/meta#337
See QuantEcon/meta#336
