### PR TITLE
FIX: remove unused get_cmap and to_rgba imports in laffer_adaptive

### DIFF
--- a/lectures/laffer_adaptive.md
+++ b/lectures/laffer_adaptive.md
@@ -170,8 +170,6 @@ from collections import namedtuple
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator
-from matplotlib.cm import get_cmap
-from matplotlib.colors import to_rgba
 import matplotlib
 from scipy.optimize import root, fsolve
 ```


### PR DESCRIPTION
## Problem

`matplotlib.cm.get_cmap` was removed in newer matplotlib releases. `laffer_adaptive.md` imports it in its first code cell, so once the runtime's matplotlib crosses that version the notebook dies before executing anything:

    ImportError: cannot import name 'get_cmap' from 'matplotlib.cm'

## Fix

Two dead imports are dropped from that cell:

| Import | Status | Why removed |
|---|---|---|
| `from matplotlib.cm import get_cmap` | **Fatal** on newer matplotlib | Never used in the lecture — dropped rather than migrated to `matplotlib.colormaps[...]` |
| `from matplotlib.colors import to_rgba` | Harmless but dead | Never used; `to_rgba` still exists in matplotlib, so this is cleanup rather than a fix |

Both were verified unused by checking every occurrence in the file — each symbol appears exactly once, on its own import line, with no reference anywhere else (compare `MaxNLocator` and `namedtuple`, which are each imported *and* used). Two lines deleted, no output changes.

## Context

This mirrors QuantEcon/lecture-python-intro#798. That fix came out of the `anaconda=2026.06 → 2026.07` validation sweep across the Python lecture family, where 2026.07's matplotlib was the release that finally dropped `get_cmap` — it was the only real regression found across all seven repos.

This repo runs under pyodide rather than the conda env, so it was outside that sweep's scope and its `environment.yml`-based validation never touched it. But it carries the identical imports and will break the same way whenever its matplotlib crosses that version. Filing it now rather than waiting for it to surface as a broken lecture.

Note for reviewers: the bare `import matplotlib` on the following line also appears unused — there are no `matplotlib.<attr>` references outside the import block. I left it in place to keep this diff aligned with what landed in lecture-python-intro#798, but happy to drop it if preferred.
