### PR TITLE
Use CORS-clean hosts for in-browser data reads

### DIFF
--- a/lectures/inequality.md
+++ b/lectures/inequality.md
@@ -247,7 +247,7 @@ The following code block imports a subset of the dataset `SCF_plus` for 2016,
 which is derived from the [Survey of Consumer Finances](https://en.wikipedia.org/wiki/Survey_of_Consumer_Finances) (SCF).
 
 ```{code-cell} ipython3
-url = 'https://github.com/QuantEcon/high_dim_data/raw/main/SCF_plus/SCF_plus_mini.csv'
+url = 'https://media.githubusercontent.com/media/QuantEcon/high_dim_data/main/SCF_plus/SCF_plus_mini.csv'
 df = pd.read_csv(url)
 df_income_wealth = df.dropna()
 ```

--- a/lectures/inflation_history.md
+++ b/lectures/inflation_history.md
@@ -73,7 +73,7 @@ Let us bring the data into pandas from a spreadsheet that is [hosted on GitHub](
 ```{code-cell} ipython3
 # Import data and clean up the index
 pyodide_http.patch_all()
-data_url = "https://github.com/QuantEcon/data-lectures/raw/main/lectures/longprices.xls"
+data_url = "https://raw.githubusercontent.com/QuantEcon/data-lectures/main/lectures/longprices.xls"
 df_fig5 = pd.read_excel(data_url, 
                         sheet_name='all', 
                         header=2, 
@@ -347,7 +347,7 @@ We prepare the data for each country
 
 ```{code-cell} ipython3
 # Import data
-data_url = "https://github.com/QuantEcon/data-lectures/raw/main/lectures/chapter_3.xlsx"
+data_url = "https://raw.githubusercontent.com/QuantEcon/data-lectures/main/lectures/chapter_3.xlsx"
 xls = pd.ExcelFile(data_url)
 
 # Select relevant sheets

--- a/lectures/long_run_growth.md
+++ b/lectures/long_run_growth.md
@@ -94,7 +94,7 @@ Here we read the Maddison data into a pandas `DataFrame`:
 
 ```{code-cell} ipython3
 pyodide_http.patch_all()
-data_url = "https://github.com/QuantEcon/data-lectures/raw/main/lectures/mpd2020.xlsx"
+data_url = "https://raw.githubusercontent.com/QuantEcon/data-lectures/main/lectures/mpd2020.xlsx"
 data = pd.read_excel(data_url, 
                      sheet_name='Full data')
 data.head()

--- a/lectures/mle.md
+++ b/lectures/mle.md
@@ -92,7 +92,7 @@ The following code imports this data  and reads it into an array called `sample`
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-url = 'https://github.com/QuantEcon/high_dim_data/raw/main/SCF_plus/SCF_plus_mini_no_weights.csv'
+url = 'https://media.githubusercontent.com/media/QuantEcon/high_dim_data/main/SCF_plus/SCF_plus_mini_no_weights.csv'
 df = pd.read_csv(url)
 df = df.dropna()
 df = df[df['year'] == 2016]


### PR DESCRIPTION
This site executes code cells in the reader's browser (Pyodide via `pyodide_http.patch_all()`), so every pandas URL read is subject to CORS on each redirect hop. The `github.com/<org>/<repo>/raw/…` form is a 302 whose response carries an empty `access-control-allow-origin` header, which browsers reject before following the redirect — so those reads fail in the one repo where the browser is the runtime. `raw.githubusercontent.com` and (for LFS files) `media.githubusercontent.com` serve `access-control-allow-origin: *` and work. The regression and the accompanying repoint rule are tracked in QuantEcon/data-lectures#46.

Five reads flipped, two groups:

| Lecture | Read | Old host | New host |
| --- | --- | --- | --- |
| `long_run_growth` | `mpd2020.xlsx` | `github.com/QuantEcon/data-lectures/raw/…` (from #52) | `raw.githubusercontent.com` |
| `inflation_history` | `longprices.xls`, `chapter_3.xlsx` | `github.com/QuantEcon/data-lectures/raw/…` (from #53) | `raw.githubusercontent.com` |
| `inequality` | `SCF_plus_mini.csv` | `github.com/QuantEcon/high_dim_data/raw/…` (pre-existing) | `media.githubusercontent.com` (LFS) |
| `mle` | `SCF_plus_mini_no_weights.csv` | `github.com/QuantEcon/high_dim_data/raw/…` (pre-existing) | `media.githubusercontent.com` (LFS) |

The `{download}` link and prose links keep the `github.com` form — they are plain navigations, CORS does not apply, and that form gives the reader the friendlier GitHub UI on click.

Verification: all five new URLs fetched from this site's own origin (`quantecon.github.io`) in headless Chromium — 200 with the exact expected sizes (1,765,204 / 388,608 / 73,281 / 32,853,734 / 75,902,999 bytes; the first three byte-identical to the sha256-verified data-lectures copies). The old form fails the same test with `Failed to fetch`. Reproduce from any `quantecon.github.io` page console: `fetch('https://github.com/QuantEcon/data-lectures/raw/main/lectures/mpd2020.xlsx')` rejects; the `raw.githubusercontent.com` equivalent resolves.

The data-lectures audit classifies references by org/repo across all GitHub URL forms, so these stay pattern `data-lectures`/unchanged — the strict migration-consistency check is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)