### PR TITLE
CI: guard against reading data-lectures over the LFS media host

### DIFF
--- a/.github/workflows/data-url-guard.yml
+++ b/.github/workflows/data-url-guard.yml
@@ -1,0 +1,38 @@
+# Code cells here execute in the reader's browser, so a dataset read on the
+# wrong host is a reader-visible failure on every page view — and this repo's
+# CI cannot see it: ci.yml runs `myst build --html` with no execution, so a
+# dead URL is fetched by nobody until a reader arrives. The data-audit
+# dashboard that would catch it lives in QuantEcon/data-lectures and never
+# runs on a pull request here.
+#
+# See QuantEcon/data-lectures PLAN.md, repoint rule 6.
+
+name: Data URL guard
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  data-url-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: No data-lectures read on the LFS media host
+        run: |
+          # media.githubusercontent.com is the LFS *media* endpoint and routes
+          # per path: it serves a file only where that path is LFS-tracked in
+          # the repo the URL names, and 404s otherwise. Everything data-lectures
+          # publishes is plain git, so this host never resolves for it — and a
+          # mechanical org/repo swap that preserves the host breaks every read.
+          #
+          # Only the media host is checked. Rule 5's github.com/*/raw/ form is
+          # wrong for code cells but correct for {download} roles and prose
+          # links, which a grep cannot tell apart — that one is asserted on
+          # code cells only, post-merge, by the strict audit in data-lectures.
+          if grep -rnF 'media.githubusercontent.com/media/QuantEcon/data-lectures' lectures/; then
+            echo "::error::Read data-lectures over raw.githubusercontent.com — that is the only CORS-clean form that resolves (repoint rule 5), and the media host is LFS-only, so it 404s every file data-lectures publishes (repoint rule 6)."
+            exit 1
+          fi
+          echo "OK — no data-lectures read on the media host."

--- a/.github/workflows/data-url-guard.yml
+++ b/.github/workflows/data-url-guard.yml
@@ -17,6 +17,11 @@ on:
 jobs:
   data-url-guard:
     runs-on: ubuntu-latest
+    # This job greps a checkout and writes nothing. The repo default is
+    # `write`, so without this it would receive a token that can also approve
+    # pull requests. ci.yml sets its own block for the same reason.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: No data-lectures read on the LFS media host
@@ -32,7 +37,7 @@ jobs:
           # links, which a grep cannot tell apart — that one is asserted on
           # code cells only, post-merge, by the strict audit in data-lectures.
           if grep -rnF 'media.githubusercontent.com/media/QuantEcon/data-lectures' lectures/; then
-            echo "::error::Read data-lectures over raw.githubusercontent.com — that is the only CORS-clean form that resolves (repoint rule 5), and the media host is LFS-only, so it 404s every file data-lectures publishes (repoint rule 6)."
+            echo "::error::Found a data-lectures read on media.githubusercontent.com — the LFS media endpoint, which 404s every file data-lectures publishes (repoint rule 6). Use raw.githubusercontent.com, which here is also the only CORS-clean form that resolves in the reader's browser (repoint rule 5)."
             exit 1
           fi
           echo "OK — no data-lectures read on the media host."


### PR DESCRIPTION
Gate 2 of QuantEcon/workspace-lectures#23 step 3, the `lecture-wasm` half. One new workflow, no lecture changes. Companion to QuantEcon/lecture-python-intro#830.

## The failure it catches

`media.githubusercontent.com` is the LFS **media** endpoint. It routes **per path**, not per repo — it serves a file only where that path is LFS-tracked in the repo the URL names, and 404s otherwise. Everything `QuantEcon/data-lectures` publishes is plain git, so the media host never resolves for it:

| URL | Result |
| --- | --- |
| `raw.githubusercontent.com/QuantEcon/data-lectures/main/lectures/mpd2020.xlsx` | **200** |
| `media.githubusercontent.com/media/QuantEcon/data-lectures/main/lectures/mpd2020.xlsx` | **404** |

Both hosts send `access-control-allow-origin: *`, so this is host routing, not CORS — a different failure from repoint rule 5, and one that hits every runtime rather than only the browser.

It is live risk here specifically: the six `high_dim_data` datasets are LFS-tracked *there*, so `heavy_tails`, `inequality` and `mle` read them from the media host today. When they land in data-lectures as plain git, **a mechanical org/repo swap that preserves the host breaks every one of them** — in the reader's browser, on every page view.

## Why this repo needs it more than intro does

`ci.yml` runs `myst build --html` with no execution, so no URL in a code cell is ever fetched by CI. A dead read is invisible here until a reader arrives. (Intro's build does execute and raises `CellExecutionError` on a 404 — a signal this repo does not have at all.)

`grep -r` over `lectures/` also walks `lectures/_static/**/*.ipynb`, which the data-lectures audit deliberately excludes from its scan — so this guard is the only mechanism of any kind that sees `_static/lecture_specific/inequality/data.ipynb`.

## Scope

**Media host only.** Rule 5's `github.com/*/raw/` form is wrong in a code cell but correct in a `{download}` role or a prose link, and this repo has both today — `french_rev.md` links three `blob/` URLs and `inflation_history.md` has a `{download}` on the raw redirect form. A grep cannot tell a code cell from a prose link, so rule 5 stays where it already is: asserted on code cells only, post-merge, by the strict audit in data-lectures.

**Matches zero lines today** — verified, `grep` exits 1 — so it goes green on merge and is armed before the fold rather than landing alongside it.

**It is an alarm, not a gate.** `main` here has no branch protection object at all, so this shows as a failed check on the PR without blocking anything. Making it binding is a separate, deliberate decision.

The companion assertion — that no `high_dim_data` URL remains anywhere — matches 7 lines here today, so it belongs in the repoint PR itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)