### PR TITLE
DIAGNOSTIC (do not merge): which code cells does thebe-lite actually execute?

### DIFF
--- a/lectures/myst.yml
+++ b/lectures/myst.yml
@@ -35,6 +35,7 @@ project:
       #       - localStorage
   toc:
     - file: intro.md
+    - file: probe_nesting
     - title: Economic Data 
       children:
         - file: long_run_growth

--- a/lectures/probe_nesting.md
+++ b/lectures/probe_nesting.md
@@ -1,4 +1,14 @@
 ---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.7
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
 title: "PROBE — which code cells actually execute?"
 ---
 

--- a/lectures/probe_nesting.md
+++ b/lectures/probe_nesting.md
@@ -59,12 +59,12 @@ print("E ok")
 
 ## F — inside a plain admonition
 
-```{note}
+````{note}
 ```{code-cell} ipython3
 ran.append("F_in_note")
 print("F ok")
 ```
-```
+````
 
 ## REPORT (top level)
 

--- a/lectures/probe_nesting.md
+++ b/lectures/probe_nesting.md
@@ -1,0 +1,78 @@
+---
+title: "PROBE — which code cells actually execute?"
+---
+
+# Probe: which code cells actually execute under thebe-lite?
+
+Temporary diagnostic page. **Not for merge.** Run the cells top to bottom, then run
+the final REPORT cell — it names every cell that actually executed, so a cell that
+silently did nothing is visible rather than ambiguous.
+
+## Setup (top level — control, must work)
+
+```{code-cell} ipython3
+ran = []
+ran.append("A_toplevel_setup")
+print("A ok")
+```
+
+## B — top level, `%%file` magic (tests the magic independently of nesting)
+
+```{code-cell} ipython3
+%%file probe_b.txt
+hello-from-B
+```
+
+```{code-cell} ipython3
+import os
+ran.append("C_toplevel_after_magic")
+print("C: probe_b.txt exists?", os.path.exists("probe_b.txt"))
+if os.path.exists("probe_b.txt"):
+    print("C: contents =", open("probe_b.txt").read().strip())
+```
+
+## D — inside a GATED exercise
+
+```{exercise-start}
+:label: probe_ex
+```
+Prose inside the gated exercise.
+
+```{code-cell} ipython3
+ran.append("D_in_gated_exercise")
+print("D ok")
+```
+```{exercise-end}
+```
+
+## E — inside a GATED solution
+
+```{solution-start} probe_ex
+:class: dropdown
+```
+```{code-cell} ipython3
+ran.append("E_in_gated_solution")
+print("E ok")
+```
+```{solution-end}
+```
+
+## F — inside a plain admonition
+
+```{note}
+```{code-cell} ipython3
+ran.append("F_in_note")
+print("F ok")
+```
+```
+
+## REPORT (top level)
+
+```{code-cell} ipython3
+expected = ["A_toplevel_setup", "C_toplevel_after_magic",
+            "D_in_gated_exercise", "E_in_gated_solution", "F_in_note"]
+print("EXECUTED:", ran)
+print("MISSING :", [e for e in expected if e not in ran])
+import os
+print("%%file worked at top level:", os.path.exists("probe_b.txt"))
+```


### PR DESCRIPTION
**Draft, never for merge.** This exists to give #64 a Netlify preview you can click, and to delete afterwards.

## Why a probe rather than reasoning

When a cell fails to execute under thebe-lite there is **no error and no output** — and for an assignment cell, "no output" is also the *correct* result. Those two states are indistinguishable by eye, which is exactly why this bug took several wrong turns: a `%%file` cell producing nothing was read as "the magic is broken" when the cell had simply never run.

So this page makes non-execution **observable**. Every cell appends a marker to a list; a final top-level REPORT cell prints which markers are present and which are `MISSING`. One click on that cell names every cell that silently did nothing.

## What it probes

| | Position | Question |
| --- | --- | --- |
| **A** | top level | control — must work |
| **B** | top level, `%%file` magic | does the magic work *at all*, independent of nesting? |
| **C** | top level, reads B's file back | did `%%file` actually write to the FS? |
| **D** | inside gated `{exercise-start}` | the position that fails in `short_path` |
| **E** | inside gated `{solution-start}` | the position that *works* in `short_path` — but only because a malformed directive spills it to root |
| **F** | inside a plain `{note}` | is this specific to exercises, or nesting generally? |

## How to run it

Open the preview's `probe_nesting` page, run the cells top to bottom, then run the **REPORT** cell. Expected output shape:

```
EXECUTED: ['A_toplevel_setup', 'C_toplevel_after_magic', ...]
MISSING : ['D_in_gated_exercise', ...]
%%file worked at top level: True
```

## What each result would mean

**If D is MISSING and A/C/E/F present** — nesting inside `{exercise}` is the cause, confirming #64, and the fix is to move the data cell out of the exercise block.

**If D and F are both MISSING** — it is nesting generally, not exercises, which is a broader and more interesting upstream report for `mystmd`/`thebe`.

**If B/C show `%%file worked at top level: True`** — this is the one that changes the design. `%%file` under thebe-lite has never actually been tested; it was assumed broken on evidence that turned out to be about the *cell not running*. If it works at top level, `lecture-wasm` can converge with `lecture-python-intro`, `lecture-dp`, `lecture-jax`, `lecture-intro.zh-cn` and `test-actions-lecture-intro` — same `%%file graph.txt` cell, same canonical `open(in_file)` helper — instead of carrying a divergent string-based variant indefinitely.

**If B/C show `False`** — `%%file` is genuinely unavailable here and the inline literal is the only option, which is worth knowing definitively rather than by assumption.

Relates to #63 and #64.