### PR TITLE
chore: bump the pinned theme to v2.3.0

### DIFF
--- a/lectures/myst.yml
+++ b/lectures/myst.yml
@@ -119,4 +119,4 @@ project:
 site:
   # Pinned theme release (see https://github.com/QuantEcon/quantecon-theme.mystmd/releases);
   # bump the vX.Y.Z in this URL to take a new theme version.
-  template: https://github.com/QuantEcon/quantecon-theme.mystmd/releases/download/v2.1.0/quantecon-theme.zip
+  template: https://github.com/QuantEcon/quantecon-theme.mystmd/releases/download/v2.3.0/quantecon-theme.zip


### PR DESCRIPTION
Bumps the pinned theme release in `lectures/myst.yml` from **v2.1.0** to **v2.3.0** ([release notes](https://github.com/QuantEcon/quantecon-theme.mystmd/releases/tag/v2.3.0)). One-line change; the pin URL is the only theme coupling.

What the jump picks up:

- **v2.3.0** — git-history changelogs in page headers (automatic, from this repo's git log at build time); opt-in in-page live compute via `project.thebe` (not enabled here, so no behavior change); and CDN-free stylesheets — KaTeX and jupyter-matplotlib now ship with the theme and Font Awesome is dropped, so maths no longer renders unstyled where jsdelivr/cdnjs are blocked (notably mainland China).
- **v2.2.0** — fancy ordered-list markers (`(a)` / `(i)` / `B)`) render correctly, plus an accessible name on the launch toolbar trigger.

Nothing in this repo needs reconfiguring: the new features are either automatic or gated behind config this repo doesn't set. The CI build against the new bundle is the verification that matters here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
